### PR TITLE
Fix target path as not writable

### DIFF
--- a/Library/LaunchDaemons/org.osx86.localtime-toggle.plist
+++ b/Library/LaunchDaemons/org.osx86.localtime-toggle.plist
@@ -5,7 +5,7 @@
 	<key>Label</key>
 	<string>org.osx86.localtime-toggle</string>
 	<key>Program</key>
-	<string>/sbin/localtime-toggle</string>
+	<string>/usr/local/bin/localtime-toggle</string>
 	<key>KeepAlive</key>
 	<true/>
 	<key>RunAtLoad</key>

--- a/fix_time_osx.sh
+++ b/fix_time_osx.sh
@@ -18,7 +18,7 @@ fi
 
 echo "Copy file to destination place..."
 
-sudo cp -R "/tmp/localtime-toggle" "/sbin/"
+sudo cp -R "/tmp/localtime-toggle" "/usr/local/bin/"
 sudo cp -R "/tmp/org.osx86.localtime-toggle.plist" "/Library/LaunchDaemons/"
 
 sudo rm /tmp/localtime-toggle
@@ -26,7 +26,7 @@ sudo rm /tmp/org.osx86.localtime-toggle.plist
 
 echo "Chmod localtime-toggle..."
 
-sudo chmod +x /sbin/localtime-toggle
+sudo chmod +x /usr/local/bin/localtime-toggle
 
 echo "Chmod org.osx86.localtime-toggle.plist..."
 


### PR DESCRIPTION
Good night. Recent versions of macOS don't allow to write /sbin directory. I've changed this to /usr/local/bin, this directory has write access with sudo.